### PR TITLE
Add Slack Gemini bot with Cloud Run deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SLACK_BOT_TOKEN="xoxb-your-slack-bot-token"
+SLACK_SIGNING_SECRET="your-slack-signing-secret"
+GOOGLE_PROJECT="your-gcp-project"
+GOOGLE_LOCATION="us-central1"
+MODEL_NAME="gemini-1.5-flash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+ENV PORT=8080
+CMD ["uvicorn", "app.main:fastapi_app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,75 @@
-# slack-gemini-bot-on-google-cloud
-Slack bot using Google Cloud’s Gemini
+# Slack Gemini Bot on Google Cloud
+
+This repository provides a Slack bot backend implemented in Python that uses [Slack Bolt](https://slack.dev/bolt-python) and Google Cloud's [Vertex AI Gemini](https://cloud.google.com/vertex-ai) model via the [google-genai](https://pypi.org/project/google-genai/) SDK. The bot responds to text or image messages and maintains conversation context within Slack threads. It is designed to run on [Cloud Run](https://cloud.google.com/run).
+
+## Features
+- Responds to `@mention` messages in Slack channels.
+- Supports text and image inputs from Slack messages. Images are fetched via authenticated URLs and sent to Gemini for multimodal understanding.
+- Maintains conversation context by retrieving prior messages in a thread and sending them as conversation history to Gemini.
+- FastAPI-based web server suitable for Cloud Run.
+- Deployment script for building and deploying to Cloud Run.
+
+## Project Structure
+```
+app/
+  main.py           # FastAPI app and Slack Bolt handlers
+scripts/
+  deploy.sh         # Helper script to deploy to Cloud Run
+Dockerfile           # Container definition for Cloud Run
+requirements.txt     # Python dependencies
+```
+
+## Prerequisites
+- Python 3.13
+- [Google Cloud SDK](https://cloud.google.com/sdk) with `gcloud` authenticated
+- Slack workspace admin privileges
+
+## Local Development
+1. Install dependencies
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Configure environment variables
+   ```bash
+   cp .env.example .env
+   # edit .env and set your Slack and Google Cloud credentials
+   ```
+3. Run the server
+   ```bash
+   uvicorn app.main:fastapi_app --host 0.0.0.0 --port 8080 --reload
+   ```
+4. Use a tunneling tool like `ngrok` to expose `http://localhost:8080/slack/events` to Slack during development.
+
+## Slack App Configuration
+1. Create a new Slack app at <https://api.slack.com/apps>.
+2. Under **OAuth & Permissions**, add the following Bot Token scopes:
+   - `app_mentions:read`
+   - `chat:write`
+   - `channels:history`
+   - `groups:history`
+   - `im:history`
+   - `mpim:history`
+   - `files:read`
+3. Install the app to your workspace to obtain `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET`.
+4. Enable **Event Subscriptions** and set the Request URL to `https://<your-cloud-run-service-url>/slack/events`.
+5. Subscribe to bot events: `app_mention`.
+6. Invite the bot to channels where you want to use it.
+
+## Deploy to Cloud Run
+The repository includes a helper script to build the container and deploy to Cloud Run. Ensure your `.env` contains `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` before running:
+
+```bash
+./scripts/deploy.sh
+```
+
+The script will:
+1. Build the container image using Cloud Build.
+2. Deploy the image to Cloud Run.
+3. Set the required environment variables on the service.
+
+After deployment, configure the Slack app's event subscription URL to the Cloud Run service URL.
+
+## License
+[Apache-2.0](LICENSE)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,81 @@
+import os
+import asyncio
+from typing import List
+
+import httpx
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request
+from slack_bolt.async_app import AsyncApp
+from slack_bolt.adapter.fastapi import AsyncSlackRequestHandler
+from google import genai
+from google.genai import types
+
+# Environment variables
+load_dotenv()
+SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
+SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
+PROJECT_ID = os.environ.get("GOOGLE_PROJECT")
+LOCATION = os.environ.get("GOOGLE_LOCATION", "us-central1")
+MODEL_NAME = os.environ.get("MODEL_NAME", "gemini-1.5-flash")
+
+# Initialize Slack Bolt AsyncApp
+bolt_app = AsyncApp(token=SLACK_BOT_TOKEN, signing_secret=SLACK_SIGNING_SECRET)
+handler = AsyncSlackRequestHandler(bolt_app)
+
+fastapi_app = FastAPI()
+
+async def _build_contents_from_thread(client, channel: str, thread_ts: str) -> List[types.Content]:
+    """Fetch thread messages and build google-genai contents."""
+    history = await client.conversations_replies(channel=channel, ts=thread_ts, limit=50)
+    contents: List[types.Content] = []
+    async with httpx.AsyncClient() as http_client:
+        for msg in history["messages"]:
+            role = "model" if msg.get("bot_id") else "user"
+            parts = []
+            text = msg.get("text")
+            if text:
+                parts.append(types.Part.from_text(text))
+            for f in msg.get("files", []):
+                mimetype = f.get("mimetype", "")
+                if mimetype.startswith("image/"):
+                    url = f.get("url_private_download")
+                    if url:
+                        resp = await http_client.get(url, headers={"Authorization": f"Bearer {SLACK_BOT_TOKEN}"})
+                        resp.raise_for_status()
+                        parts.append(types.Part.from_bytes(resp.content, mime_type=mimetype))
+            if parts:
+                contents.append(types.Content(role=role, parts=parts))
+    return contents
+
+@bolt_app.event("app_mention")
+async def handle_mention(body, say, client, logger):
+    event = body["event"]
+    channel = event["channel"]
+    thread_ts = event.get("thread_ts") or event["ts"]
+
+    contents = await _build_contents_from_thread(client, channel, thread_ts)
+
+    def call_gemini() -> str:
+        genai_client = genai.Client(vertexai=True, project=PROJECT_ID, location=LOCATION)
+        response = genai_client.models.generate_content(model=MODEL_NAME, contents=contents)
+        return response.text
+
+    try:
+        reply_text = await asyncio.to_thread(call_gemini)
+    except Exception as e:
+        logger.exception("Gemini call failed")
+        reply_text = f"Error from Gemini: {e}"
+
+    await say(reply_text, thread_ts=thread_ts)
+
+@fastapi_app.post("/slack/events")
+async def slack_events(req: Request):
+    return await handler.handle(req)
+
+@fastapi_app.get("/")
+async def root():
+    return {"status": "ok"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("app.main:fastapi_app", host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+slack_bolt>=1.18.0
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+google-genai>=1.31.0
+httpx>=0.27.0
+python-dotenv>=1.0.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load environment variables from .env if present
+if [[ -f .env ]]; then
+  # shellcheck disable=SC1091
+  source .env
+fi
+
+SERVICE_NAME=${SERVICE_NAME:-slack-gemini-bot}
+REGION=${REGION:-us-central1}
+PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value project)}
+IMAGE="gcr.io/${PROJECT_ID}/${SERVICE_NAME}"
+
+if [[ -z "${SLACK_BOT_TOKEN:-}" || -z "${SLACK_SIGNING_SECRET:-}" ]]; then
+  echo "SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET environment variables must be set" >&2
+  exit 1
+fi
+
+gcloud builds submit --tag "$IMAGE"
+
+gcloud run deploy "$SERVICE_NAME" \
+  --image "$IMAGE" \
+  --region "$REGION" \
+  --platform managed \
+  --allow-unauthenticated \
+  --set-env-vars "SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN},SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET},GOOGLE_PROJECT=${PROJECT_ID},GOOGLE_LOCATION=${REGION}"


### PR DESCRIPTION
## Summary
- implement Slack Bolt + FastAPI backend that forwards text and image inputs to Vertex AI Gemini and keeps thread history for context
- provide Dockerfile, requirements, and deployment script for Cloud Run
- document local development, Slack app configuration, and deployment steps
- switch to the google-genai SDK for Gemini interactions
- load configuration from `.env` in the app and deployment script

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c4ead9dc832abd23f7f1eb11a79a