### PR TITLE
Use Slack markdown for bot responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository provides a Slack bot backend implemented in Python that uses [Sl
 - Responds to `@mention` messages in Slack channels.
 - Supports text and image inputs from Slack messages. Images are fetched via authenticated URLs and sent to Gemini for multimodal understanding.
 - Maintains conversation context by retrieving prior messages in a thread and sending them as conversation history to Gemini.
+- Formats responses using Slack-compatible Markdown for rich text output.
 - FastAPI-based web server suitable for Cloud Run.
 - Deployment script for building and deploying to Cloud Run.
 

--- a/app/main.py
+++ b/app/main.py
@@ -102,7 +102,11 @@ async def handle_mention(body, say, client, logger):
         logger.exception("Gemini call failed")
         reply_text = f"Error from Gemini: {e}"
 
-    await say(reply_text, thread_ts=thread_ts)
+    await say(
+        blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": reply_text}}],
+        text=reply_text,
+        thread_ts=thread_ts,
+    )
 
 @fastapi_app.post("/slack/events")
 async def slack_events(req: Request):


### PR DESCRIPTION
## Summary
- format Gemini replies using Slack `mrkdwn` blocks
- document that bot outputs Slack Markdown

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5eebb4f90832a8100bc42acbf8557